### PR TITLE
[DRAFT] Add support for custom fonts and improve rendering accuracy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+fonts/
+.DS_Store

--- a/Inkplate.js
+++ b/Inkplate.js
@@ -3,8 +3,6 @@ class Inkplate {
         this.ctx = ctx;
         this.canvas = canvas;
 
-        this.scale = 1.0;
-
         this.xOffset = 0;
         this.yOffset = 0;
 
@@ -12,6 +10,7 @@ class Inkplate {
 
         this.width = globalW;
         this.height = globalH;
+        this.dpi = globalDPI;
 
         this.cursor = {
             x: 0,
@@ -20,7 +19,6 @@ class Inkplate {
 
         this.color = 0;
 
-        this.fontSize = "32px";
         this.font = "FreeSansBold24pt7b";
     }
 
@@ -313,9 +311,8 @@ class Inkplate {
     }
 
     setFontSize(s) {
-        // Set the font size for `s` in points (1/72")
-        // This constant is tuned for the inkplate 6
-        this.fontSize = s * 3.1389;
+        // Set the font size in pixels given `s` in points (1/72")
+        this.fontSize = s * (this.dpi / 72);
     }
 
     setCursor(x, y) {
@@ -325,7 +322,6 @@ class Inkplate {
 
     print(text) {
         this.ctx.fillStyle = `rgb(${this.color << 5}, ${this.color << 5}, ${this.color << 5})`;
-        // TODO: Print using a custom font here
         this.ctx.font = parseInt(this.fontSize) + "px " + this.font;
 
         let maxWidth = globalW - this.cursor.x + this.outline;

--- a/Inkplate.js
+++ b/Inkplate.js
@@ -32,10 +32,6 @@ class Inkplate {
         return this.yOffset + this.outline + y * (600 / globalH);
     }
 
-    setFontSize(s) {
-        this.fontSize = s;
-    }
-
     drawOutline() {
         let _width = this.width + 2 * this.outline;
         let _height = this.height + 2 * this.outline;
@@ -316,6 +312,12 @@ class Inkplate {
         this.font = font;
     }
 
+    setFontSize(s) {
+        // Set the font size for `s` in points (1/72")
+        // This constant is tuned for the inkplate 6
+        this.fontSize = s * 3.1389;
+    }
+
     setCursor(x, y) {
         this.cursor.x = this.scaleX(x);
         this.cursor.y = this.scaleY(y);
@@ -323,7 +325,8 @@ class Inkplate {
 
     print(text) {
         this.ctx.fillStyle = `rgb(${this.color << 5}, ${this.color << 5}, ${this.color << 5})`;
-        this.ctx.font = parseInt(this.fontSize) + "px Arial";
+        // TODO: Print using a custom font here
+        this.ctx.font = parseInt(this.fontSize) + "px " + this.font;
 
         let maxWidth = globalW - this.cursor.x + this.outline;
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@ Web app for designing GUI for Inkplate e-paper displays
 
 # Configuring Fonts
 
-The GUI editor is capable of rendering fonts in an accurate way to how
-Adafruit GFX will render them on an Inkplate device. Currently this is
-only scaled appropriately for the Inkplate 6, but this can be extended.
+The GUI editor is capable of rendering fonts in an accurate way to how Adafruit
+GFX will render them on an Inkplate device.
 
-To use custom fonts, place TTF fonts in the `fonts/` folder, and update
+By default, `fonts.css` is configured with a list of the basic GNU FreeFont
+fonts typically used in the [Adafruit GFX font tutorial](https://learn.adafruit.com/adafruit-gfx-graphics-library/using-fonts).
+You can acquire the TTFs from their [project page](http://savannah.gnu.org/projects/freefont/)
+and place them in the `fonts/` folder for the GUI designer to use them.
+
+To use custom fonts, place any TTF font in the `fonts/` folder, and update
 `fonts.css` to add references to them.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Inkplate-GUI-Designer
 Web app for designing GUI for Inkplate e-paper displays
+
+# Configuring Fonts
+
+The GUI editor is capable of rendering fonts in an accurate way to how
+Adafruit GFX will render them on an Inkplate device. Currently this is
+only scaled appropriately for the Inkplate 6, but this can be extended.
+
+To use custom fonts, place TTF fonts in the `fonts/` folder, and update
+`fonts.css` to add references to them.

--- a/Screen.js
+++ b/Screen.js
@@ -41,7 +41,7 @@ class Screen {
             //new rect(0, 0, 100, 100, 0, false, 0, false),
             //new circle(100, 100, 50, 4, true),
             //new triangle(0, 0, 100, 100, 100, 0, 5, true),
-            new text(300, 290, "Hello there!", "24px FreeSansBold24pt7b", 0)
+            new text(300, 290, "Hello there!", "FreeSansBold24pt7b", 0)
         ];
 
         this.editComponent(this.entities[0]);
@@ -326,8 +326,8 @@ class Screen {
                 else if (!e.radius && !e.fill)
                     this.display.drawRect(e["a"].x, e["a"].y, e["c"].x - e["a"].x, e["c"].y - e["a"].y, e["color"]);
             } else if (e.type == "text") {
-                this.display.setFont(e["font"]);
-                this.display.setFontSize(e["size"]);
+                this.display.setFont(e.getFontFamily());
+                this.display.setFontSize(e.getFontSize());
                 this.display.setFontColor(e["color"]);
                 this.display.setCursor(e["cursor"].x, e["cursor"].y);
                 this.display.print(e["content"]);

--- a/fonts.css
+++ b/fonts.css
@@ -1,0 +1,59 @@
+@font-face {
+  font-family: "FreeMono";
+  src: url("/fonts/FreeMono.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeMonoBold";
+  src: url("/fonts/FreeMonoBold.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeMonoBoldOblique";
+  src: url("/fonts/FreeMonoBoldOblique.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeMonoOblique";
+  src: url("/fonts/FreeMonoOblique.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSans";
+  src: url("/fonts/FreeSans.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSansBold";
+  src: url("/fonts/FreeSansBold.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSansBoldOblique";
+  src: url("/fonts/FreeSansBoldOblique.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSansOblique";
+  src: url("/fonts/FreeSansOblique.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSerif";
+  src: url("/fonts/FreeSerif.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSerifBold";
+  src: url("/fonts/FreeSerifBold.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSerifBoldItalic";
+  src: url("/fonts/FreeSerifBoldItalic.ttf") format("truetype");
+}
+
+@font-face {
+  font-family: "FreeSerifItalic";
+  src: url("/fonts/FreeSerifItalic.ttf") format("truetype");
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       rel="stylesheet"
     />
     <link href="style.css" rel="stylesheet" />
+    <link href="fonts.css" rel="stylesheet" />
   </head>
   <body>
     <div class="wrapper">

--- a/primitives.js
+++ b/primitives.js
@@ -649,7 +649,6 @@ class text {
         }
         this["content"] = text;
         this["font"] = font;
-        this["size"] = "32px";
         this["color"] = c;
 
         this.modifiers = [
@@ -674,11 +673,6 @@ class text {
             "font": {
                 type: "text",
                 default: "FreeSansBold24pt7b",
-                optional: false
-            },
-            "size": {
-                type: "text",
-                default: "32px",
                 optional: false
             },
             "color": {
@@ -709,6 +703,20 @@ class text {
             `    display.setCursor(text${this.id}_cursor_x, text${this.id}_cursor_y);\n` +
             `    display.print(text${this.id}_content);\n` +
             `\n`;
+    }
+
+    getFontSize() {
+        // Get the font size in points (1/72") from the font name
+        const re = /\D+(\d+)pt7b/;
+        const match = this.font.match(re);
+        return match[1];
+    }
+
+    getFontFamily() {
+        // Get the font family based on the font name
+        const re = /(\D+)\d+pt7b/;
+        const match = this.font.match(re);
+        return match[1];
     }
 
     mouseOn(x, y) {

--- a/settingsTab.js
+++ b/settingsTab.js
@@ -1,22 +1,28 @@
 let globalW = 800;
 let globalH = 600;
+let globalDPI = 167;
 
 function changeInkplate() {
     if (document.getElementById("sel1").value == "Inkplate 6") {
         globalW = 800;
         globalH = 600;
+        globalDPI = 167;
     } else if (document.getElementById("sel1").value == "Inkplate 6+") {
         globalW = 1024;
         globalH = 758;
+        globalDPI = 212;
     } else if (document.getElementById("sel1").value == "Inkplate 10") {
         globalW = 1200;
         globalH = 825;
+        globalDPI = 150;
     } else if (document.getElementById("sel1").value == "Inkplate 5") {
         globalW = 800;
         globalH = 600;
+        globalDPI = 167;
     } else if (document.getElementById("sel1").value == "Inkplate Color") {
         globalW = 600;
         globalH = 448;
+        globalDPI = 133;
     }
 
     screen.ui.width = globalW;


### PR DESCRIPTION
### Intro/Background

Currently, the font rendering in the GUI designer does not provide an accurate representation of how a text field will look when rendered on a device. This is a first-pass at making the offboard->onboard renders more accurate, and also adds support for rendering arbitrary fonts in the GUI editor.

I'm opening this primarily for discussion on the right way to handle this generically, and am happy to take feedback to get something ready to merge.

### What this does

- Adds support for rendering arbitrary TTF fonts via the `fonts/` folder and `fonts.css`
- Switches to using font names + sizes in the style of Adafruit GFX's `<FontName><FontSizeInPoints>` pattern, to better match font names as reflected by the Adafruit documentation
- Dynamically scales the custom fonts based on device DPIs

### Remaining Work

- Testing on other devices - I have only tested accuracy on an Inkplate 6
- Determine how the use of TTF fonts in the `fonts/` folder will affect the [hosted version](https://inkplate.io/home/gui-editor/)
- [Documentation](https://inkplate.readthedocs.io/en/latest/gui-designer.html#using-fonts) updates

### Known Issues

- Line wrap behavior and overall line height are still not accurately modeled by the GUI editor - though I believe this to be out of scope for this PR